### PR TITLE
fix: Prevent out-of-bounds panic in addTodoHandler for todo-webapp (incident #998877)

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,14 +210,12 @@ func addTodoHandler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[WARN] addTodoHandler: Empty todo text provided")
 		http.Error(w, "Todo text is required", http.StatusBadRequest)
 		return
-	}
-
-	// New Feature
 	if len(text) > 3 && text[:3] == "bug" {
 		log.Printf("[DEBUG] addTodoHandler: Processing special validation for text starting with 'bug'")
-		// Intentionally accessing array out of bounds to simulate a common bug
+		// Fix: prevent out of bounds by using the correct index 1 instead of 5
 		validationRules := []string{"length", "content"}
-		log.Printf("[DEBUG] addTodoHandler: Applying validation rule: %s", validationRules[5]) // This will panic!
+		log.Printf("[DEBUG] addTodoHandler: Applying validation rule: %s", validationRules[1]) // Correct index
+	}
 	}
 
 	log.Printf("[INFO] addTodoHandler: Adding new todo with text='%s'", text)


### PR DESCRIPTION
### Incident ID: 998877
### Incident Time: 20:55 AM IST 22 Jun 2025

### Description:
A runtime panic caused by an out-of-bounds slice access in `addTodoHandler` function led to HTTP 500 errors for the `todo-webapp` deployment.

### Root Cause:
The handler attempted to access `validationRules[5]` when the slice had only 2 elements, causing a runtime panic.

### Fix:
- Corrected the index access from 5 to 1 in the validationRules slice inside `addTodoHandler`.

### Impact:
This fix eliminates the panic and prevents 500 internal server errors for this code path.

### Verification:
Build and run tests to verify no runtime panics.

Please review and merge this fix.