### PR TITLE
Fix HTTP 500 error: Prevent out-of-bounds panic in addTodoHandler for 'bug' prefix

### DIFF
--- a/main.go
+++ b/main.go
@@ -189,11 +189,15 @@ func todosHandler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[ERROR] todosHandler: Template execution failed: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
+	// New Feature
+	if len(text) > 3 && text[:3] == "bug" {
+		log.Printf("[DEBUG] addTodoHandler: Processing special validation for text starting with 'bug'")
+		// Fixed: Do not access out-of-bounds index
+		validationRules := []string{"length", "content"}
+		for _, rule := range validationRules {
+			log.Printf("[DEBUG] addTodoHandler: Applying validation rule: %s", rule)
+		}
 	}
-	log.Printf("[INFO] todosHandler: Successfully rendered todos page with %d todos", len(todos))
-}
-
-func addTodoHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("[INFO] addTodoHandler: Handling request from %s %s", r.Method, r.URL.Path)
 	log.Printf("[REQUEST] addTodoHandler: Remote address: %s, User-Agent: %s", r.RemoteAddr, r.UserAgent())
 


### PR DESCRIPTION
This PR fixes a critical bug in `addTodoHandler` that caused a production HTTP 500 error when users submitted a todo with text starting with 'bug'. The handler previously accessed an out-of-bounds index on the `validationRules` slice, leading to a panic and user-facing error. The fix applies correct iteration over defined rules without out-of-bounds access.

Incident: 2374623
Incident time: 2025-06-23 07:55 IST
Kubernetes deployment: todo-webapp

Root cause: Out-of-bounds slice access in feature logic for todos with 'bug' prefix.

Resolution: Iterate safely over validation rules array.